### PR TITLE
Change native variant to curl for better stream control

### DIFF
--- a/bdi
+++ b/bdi
@@ -17,13 +17,13 @@ use DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver;
 use DBrekelmans\BrowserDriverInstaller\Driver\GeckoDriver;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Component\HttpClient\CurlHttpClient;
 
 require __DIR__ . '/vendor/autoload.php';
 
 $application = new Application();
 
-$httpClient = new NativeHttpClient();
+$httpClient = new CurlHttpClient();
 $filesystem = new Filesystem();
 $zipArchive = new ZipArchive();
 $shellCommandLineEnv = new ShellCommandLineEnvironment();


### PR DESCRIPTION
Currently the package used native variant of stream with php. Some  of the external packages are not happy with php stream and strict firewall. The fix uses Curl http client to prevent the timeout errors.

Our research has shown that Curl does work.